### PR TITLE
feat: Add responsive registration form MyForm5

### DIFF
--- a/frontend/src/component/MUITextAreaInput.jsx
+++ b/frontend/src/component/MUITextAreaInput.jsx
@@ -1,0 +1,34 @@
+/* eslint-disable react/prop-types */
+import { memo, useEffect, useRef } from "react";
+import { useField } from "formik";
+import { TextField } from "@mui/material";
+
+const MUITextAreaInput = ({ label, id, name, placeholder, rows = 4, ...props }) => {
+  const renderCount = useRef(0);
+  renderCount.current += 1;
+  const [field, meta] = useField(name);
+
+  useEffect(() => {
+    console.log(
+      `MUITextAreaInput [${name}] rendered ${renderCount.current} times`
+    );
+  });
+  return (
+    <TextField
+      fullWidth
+      label={label}
+      id={id}
+      placeholder={placeholder}
+      multiline={true}
+      rows={rows}
+      {...field}
+      {...props}
+      error={Boolean(meta.touched && meta.error)}
+      helperText={meta.touched && meta.error}
+      margin="normal"
+      variant="outlined"
+    />
+  );
+};
+
+export default memo(MUITextAreaInput);

--- a/frontend/src/pages/MyForm5.jsx
+++ b/frontend/src/pages/MyForm5.jsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { Formik } from 'formik';
+import * as yup from 'yup';
+import { Box, Button, Typography, Container } from '@mui/material';
+import MUITextInput from '../component/MUITextInput';
+import MUITextAreaInput from '../component/MUITextAreaInput';
+
+const initialValues = {
+  firstName: '',
+  lastName: '',
+  address: '',
+  email: '',
+  password: '',
+  confirmPassword: '',
+};
+
+const validationSchema = yup.object({
+  firstName: yup.string().required('Required'),
+  lastName: yup.string().required('Required'),
+  address: yup.string().required('Required'),
+  email: yup.string().email('Invalid email format').required('Required'),
+  password: yup.string().min(8, 'Password must be at least 8 characters').required('Required'),
+  confirmPassword: yup
+    .string()
+    .oneOf([yup.ref('password'), null], 'Passwords must match')
+    .required('Required'),
+});
+
+const MyForm5 = () => {
+  return (
+    <Container>
+      <Typography variant="h4" gutterBottom>
+        MyForm5
+      </Typography>
+      <Formik
+        initialValues={initialValues}
+        validationSchema={validationSchema}
+        onSubmit={(values, { setSubmitting }) => {
+          console.log("Form Values:", values);
+          setSubmitting(false);
+        }}
+        validateOnBlur={true}
+        validateOnChange={false}
+      >
+        {(formik) => (
+          <form onSubmit={formik.handleSubmit}>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, mt: 2 }}>
+              <MUITextInput name="firstName" label="First Name" id="firstName" />
+              <MUITextInput name="lastName" label="Last Name" id="lastName" />
+              <MUITextAreaInput name="address" label="Address" id="address" rows={4} />
+              <MUITextInput name="email" label="Email" id="email" type="email" />
+              <MUITextInput name="password" label="Password" id="password" type="password" />
+              <MUITextInput name="confirmPassword" label="Confirm Password" id="confirmPassword" type="password" />
+              <Button type="submit" variant="contained" color="primary" sx={{ mt: 2 }}>
+                Submit
+              </Button>
+            </Box>
+          </form>
+        )}
+      </Formik>
+    </Container>
+  );
+};
+
+export default MyForm5;


### PR DESCRIPTION
I implemented a new registration form in `frontend/src/pages/MyForm5.jsx`.

Key features:
- Uses Formik for form state management and Yup for validation.
- Fields: First Name, Last Name, Address, Email, Password, Confirm Password.
- Validation occurs on blur, with error messages displayed per field.
- Form values are logged to the console on successful submission.

Reusable Components:
- Leveraged existing `MUITextInput`.
- Created a new reusable `MUITextAreaInput` component in `frontend/src/component/MUITextAreaInput.jsx`, using Material UI's `TextField` with `multiline` prop for the address field. Both input components are integrated with Formik.

Best Practices:
- Followed guidelines for simplicity, modularity, performance (memoized components, controlled re-renders), scalability, maintainability, and reusability.
- Custom input components are designed for easy reuse and maintenance.