### PR TITLE
feat: Add password strength indicator to CustomTextField

### DIFF
--- a/frontend/src/shared/components/MUI.Components/CustomTextField.jsx
+++ b/frontend/src/shared/components/MUI.Components/CustomTextField.jsx
@@ -1,14 +1,33 @@
-import { IconButton, InputAdornment, TextField, useTheme } from "@mui/material";
+import { IconButton, InputAdornment, TextField, useTheme, Box, Typography, LinearProgress } from "@mui/material";
 import { useField } from "formik";
-import { memo, useState } from "react";
+import { memo, useState, Fragment } from "react";
 import { Eye, EyeClosed } from "lucide-react";
+import { calculatePasswordStrength, strengthLevels } from "../../utils/passwordStrength";
 
 const CustomTextField = memo(
   ({ label, name, fieldType = "text", ...props }) => {
     const [field, meta] = useField(name);
     const [showPassword, setShowPassword] = useState(false);
+    const [isPasswordFocused, setIsPasswordFocused] = useState(false);
+    const password = field.value;
     const isPasswordField = fieldType === "password";
     const theme = useTheme();
+
+    const strength = calculatePasswordStrength(password || '');
+    const currentStrengthLevelDetails = strengthLevels[strength.level];
+
+    const handleFocus = () => {
+      if (isPasswordField) {
+        setIsPasswordFocused(true);
+      }
+    };
+
+    const handleBlur = (e) => { // Pass the event 'e'
+      if (isPasswordField) {
+        setIsPasswordFocused(false);
+      }
+      field.onBlur(e); // Call Formik's onBlur with the event
+    };
 
     const textFieldProps = {
       ...field,
@@ -18,8 +37,10 @@ const CustomTextField = memo(
       fullWidth: true,
       margin: "normal",
       variant: "outlined",
-      error: meta.touched && meta.error,
-      helperText: meta.touched && meta.error,
+      error: meta.touched && Boolean(meta.error), // Ensure error is boolean
+      helperText: meta.touched && meta.error ? meta.error : "",
+      onFocus: handleFocus,
+      onBlur: handleBlur, // Use custom handleBlur that also calls Formik's onBlur
     };
 
     if (isPasswordField) {
@@ -27,7 +48,7 @@ const CustomTextField = memo(
         endAdornment: (
           <InputAdornment position="end">
             <IconButton
-              sx={{ color: theme.palette.secondary.main }} // Set icon color from theme
+              sx={{ color: theme.palette.secondary.main }}
               onClick={() => setShowPassword(!showPassword)}
               edge="end"
             >
@@ -37,7 +58,29 @@ const CustomTextField = memo(
         ),
       };
     }
-    return <TextField {...textFieldProps} />;
+
+    return (
+      <Fragment>
+        <TextField {...textFieldProps} />
+        {isPasswordField && isPasswordFocused && password && password.length > 0 && currentStrengthLevelDetails && currentStrengthLevelDetails.text !== '' && (
+          <Box sx={{ mt: 0.5, mb: !(meta.touched && meta.error) ? 2.5 : 0 }}>
+            <LinearProgress
+              variant="determinate"
+              value={Math.min((strength.score / 5) * 100, 100)}
+              color={currentStrengthLevelDetails.color.split('.')[0]}
+              sx={{ height: '6px', borderRadius: '3px', mb: 0.75 }}
+            />
+            <Typography
+              variant="caption"
+              color={currentStrengthLevelDetails.color}
+              sx={{ display: 'block' }}
+            >
+              {currentStrengthLevelDetails.text}
+            </Typography>
+          </Box>
+        )}
+      </Fragment>
+    );
   }
 );
 

--- a/frontend/src/shared/utils/passwordStrength.js
+++ b/frontend/src/shared/utils/passwordStrength.js
@@ -1,0 +1,76 @@
+export const strengthLevels = {
+  Weak: { text: 'Weak', color: 'error.main' },
+  Medium: { text: 'Medium', color: 'warning.main' },
+  Strong: { text: 'Strong', color: 'success.main' },
+  Default: { text: '', color: 'transparent' } // Added a default for initial state
+};
+
+export const calculatePasswordStrength = (password) => {
+  let score = 0;
+  const criteriaMet = [];
+
+  if (!password || password.length === 0) {
+    return { score, level: 'Default', criteriaMet };
+  }
+
+  // Criteria definitions (aligned with common Yup validation)
+  const criteria = {
+    length: {
+      regex: /.{8,}/, // Minimum 8 characters
+      message: 'Minimum 8 characters',
+    },
+    lowercase: {
+      regex: /[a-z]/,
+      message: 'Includes lowercase letter',
+    },
+    uppercase: {
+      regex: /[A-Z]/,
+      message: 'Includes uppercase letter',
+    },
+    number: {
+      regex: /[0-9]/,
+      message: 'Includes number',
+    },
+    specialChar: {
+      regex: /[@$!%*?&]/, // Common special characters
+      message: 'Includes special character (@$!%*?&)',
+    },
+  };
+
+  // Check each criterion
+  if (criteria.length.regex.test(password)) {
+    score++;
+    criteriaMet.push(criteria.length.message);
+  }
+  if (criteria.lowercase.regex.test(password)) {
+    score++;
+    criteriaMet.push(criteria.lowercase.message);
+  }
+  if (criteria.uppercase.regex.test(password)) {
+    score++;
+    criteriaMet.push(criteria.uppercase.message);
+  }
+  if (criteria.number.regex.test(password)) {
+    score++;
+    criteriaMet.push(criteria.number.message);
+  }
+  if (criteria.specialChar.regex.test(password)) {
+    score++;
+    criteriaMet.push(criteria.specialChar.message);
+  }
+
+  // Determine strength level
+  let level = 'Default'; // Start with Default
+  if (password.length > 0) { // Only evaluate if password is not empty
+    if (score <= 2) {
+      level = 'Weak';
+    } else if (score <= 4) {
+      level = 'Medium';
+    } else if (score >= 5) {
+      level = 'Strong';
+    }
+  }
+
+
+  return { score, level, criteriaMet };
+};


### PR DESCRIPTION
I've implemented a password strength indicator in `CustomTextField.jsx` for password type fields.

Key changes:
- I created `frontend/src/shared/utils/passwordStrength.js`:
    - This exports a `calculatePasswordStrength(password)` function to determine strength (Weak, Medium, Strong) based on length, uppercase, lowercase, numbers, and special characters, aligning with existing Yup validation.
    - It also exports a `strengthLevels` constant for UI display (text and MUI colors).

- I modified `frontend/src/shared/components/MUI.Components/CustomTextField.jsx`:
    - I integrated `calculatePasswordStrength` to evaluate password input in real-time.
    - I added an `isPasswordFocused` state to control indicator visibility.
    - The strength indicator (MUI `LinearProgress` and `Typography`) is displayed below the password field only when the field is focused and contains input.
    - The indicator disappears when the field loses focus.
    - I ensured Formik's `onBlur` validation and existing `helperText` for errors continue to function correctly.
    - I adjusted the layout dynamically to account for the presence/absence of validation helper text.

This feature enhances your experience during signup by providing immediate feedback on password security. The changes are encapsulated within the shared `CustomTextField` component, making the indicator automatically available wherever this component is used for password fields (e.g., in `SignUp.jsx` via `FormField`).