### PR TITLE
fix(blog): handle blog data cleanup in useEffect and remove duplicate…

### DIFF
--- a/frontend/src/features/blog/pages/BlogForm.jsx
+++ b/frontend/src/features/blog/pages/BlogForm.jsx
@@ -234,7 +234,11 @@ const BlogForm = () => {
         setBlogData(newBlogData);
       }
     }
-  }, [isEditMode, fetchedBlog, setBlogData, blog]);
+
+    return () => {
+      clearBlogData();
+    };
+  }, [isEditMode, fetchedBlog, setBlogData, blog, clearBlogData]);
 
   const debouncedAutoSave = useCallback(
     debounce((nextValues, setFieldValue) => {
@@ -322,7 +326,6 @@ const BlogForm = () => {
         { id: values._id, blogData: values },
         {
           onSuccess: () => {
-            clearBlogData();
             navigate("/");
           },
         }
@@ -331,7 +334,6 @@ const BlogForm = () => {
       console.log("create blog", values);
       publishBlog(values, {
         onSuccess: () => {
-          clearBlogData();
           navigate("/");
         },
       });

--- a/frontend/src/shared/store/blogStore.js
+++ b/frontend/src/shared/store/blogStore.js
@@ -30,7 +30,7 @@ const INITIAL_BLOG_STATE = {
   },
   createdAt: null,
   updatedAt: null,
-  category: { _id: null, name: "" },
+  category: null,
 };
 
 const useBlogStore = create(


### PR DESCRIPTION
… calls

Move clearBlogData call to useEffect cleanup to ensure proper cleanup when component unmounts. Remove duplicate clearBlogData calls from success handlers since cleanup is now handled by useEffect.